### PR TITLE
Clone Model and Spawn Creature from CreatureType

### DIFF
--- a/app/migrations/20220605173554-create-action-pattern.js
+++ b/app/migrations/20220605173554-create-action-pattern.js
@@ -12,6 +12,7 @@ module.exports = {
         type: Sequelize.INTEGER,
       },
       priority: {
+        defaultValue: 0,
         type: Sequelize.INTEGER,
       },
       createdAt: {

--- a/app/models/action.js
+++ b/app/models/action.js
@@ -15,7 +15,7 @@ module.exports = (sequelize, DataTypes) => {
      * @returns {Promise<Action>} a copy of the given action, with
      * `index` set to be the max + 1 over sibling instances.
      */
-    static clone = async (action) => {
+    static async cloneInstance(action) {
       delete action.id;
       action.index = Math.max(...(await Action.findAll({
         where: { actionPatternId: action.actionPatternId },
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
           await action.reload();
           return newAction.reload();
         });
-    };
+    }
 
     /**
      * Helper method for defining associations.

--- a/app/models/action.js
+++ b/app/models/action.js
@@ -11,27 +11,6 @@ const {
 module.exports = (sequelize, DataTypes) => {
   class Action extends Model {
     /**
-     * @param {Action} action
-     * @returns {Promise<Action>} a copy of the given action, with
-     * `index` set to be the max + 1 over sibling instances.
-     */
-    static async cloneInstance(action) {
-      delete action.id;
-      action.index = Math.max(...(await Action.findAll({
-        where: { actionPatternId: action.actionPatternId },
-        attributes: { include: ['index'] },
-      }))
-        .map((ap) => ap.index))
-        + 1;
-      // Return a copy of the action after reloading the original action in-place
-      return Action.scope('defaultScope').create({ ...action.dataValues })
-        .then(async (newAction) => {
-          await action.reload();
-          return newAction.reload();
-        });
-    }
-
-    /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.

--- a/app/models/actionPattern.js
+++ b/app/models/actionPattern.js
@@ -36,7 +36,7 @@ module.exports = (sequelize, DataTypes) => {
 
       ActionPattern.addScope('defaultScope', {
         include: [{
-          model: Action.scope('defaultScope'),
+          model: Action,
           as: 'actions',
           order: [['index', 'ASC']],
         }],

--- a/app/models/actionPattern.js
+++ b/app/models/actionPattern.js
@@ -5,6 +5,27 @@ const {
 module.exports = (sequelize, DataTypes) => {
   class ActionPattern extends Model {
     /**
+     * @param {ActionPattern} actionPattern
+     * @returns {Promise<ActionPattern>} a copy of the given actionPattern, with
+     * `priority` set to be the max + 1 over sibling instances.
+     */
+    static clone = async (actionPattern) => {
+      delete actionPattern.id;
+      actionPattern.priority = Math.max(...(await ActionPattern.findAll({
+        where: { creatureTypeId: actionPattern.creatureTypeId },
+        attributes: { include: ['priority'] },
+      }))
+        .map((ap) => ap.priority))
+        + 1;
+      // Return a copy of the actionPattern after reloading the original actionPattern in-place
+      return ActionPattern.scope('defaultScope').create({ ...actionPattern.dataValues })
+        .then(async (newActionPattern) => {
+          await actionPattern.reload();
+          return newActionPattern.reload();
+        });
+    };
+
+    /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.
@@ -15,7 +36,7 @@ module.exports = (sequelize, DataTypes) => {
 
       ActionPattern.addScope('defaultScope', {
         include: [{
-          model: Action,
+          model: Action.scope('defaultScope'),
           as: 'actions',
           order: [['index', 'ASC']],
         }],
@@ -25,7 +46,7 @@ module.exports = (sequelize, DataTypes) => {
     static optionsSchema = {
       // required, searchable, updateable
       creatureTypeId: sequelize.modelOptsObject(true, true, false),
-      priority: sequelize.modelOptsObject(true, true, true),
+      priority: sequelize.modelOptsObject(false, true, true),
     };
 
     static allowedParams = Object.keys(this.optionsSchema);
@@ -42,6 +63,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
     },
     priority: {
+      defaultValue: 0,
       type: DataTypes.INTEGER,
       validate: { min: 0 },
     },

--- a/app/models/actionPattern.js
+++ b/app/models/actionPattern.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
      * @returns {Promise<ActionPattern>} a copy of the given actionPattern, with
      * `priority` set to be the max + 1 over sibling instances.
      */
-    static clone = async (actionPattern) => {
+    static async cloneInstance(actionPattern) {
       delete actionPattern.id;
       actionPattern.priority = Math.max(...(await ActionPattern.findAll({
         where: { creatureTypeId: actionPattern.creatureTypeId },
@@ -23,7 +23,7 @@ module.exports = (sequelize, DataTypes) => {
           await actionPattern.reload();
           return newActionPattern.reload();
         });
-    };
+    }
 
     /**
      * Helper method for defining associations.

--- a/app/models/actionPattern.js
+++ b/app/models/actionPattern.js
@@ -5,27 +5,6 @@ const {
 module.exports = (sequelize, DataTypes) => {
   class ActionPattern extends Model {
     /**
-     * @param {ActionPattern} actionPattern
-     * @returns {Promise<ActionPattern>} a copy of the given actionPattern, with
-     * `priority` set to be the max + 1 over sibling instances.
-     */
-    static async cloneInstance(actionPattern) {
-      delete actionPattern.id;
-      actionPattern.priority = Math.max(...(await ActionPattern.findAll({
-        where: { creatureTypeId: actionPattern.creatureTypeId },
-        attributes: { include: ['priority'] },
-      }))
-        .map((ap) => ap.priority))
-        + 1;
-      // Return a copy of the actionPattern after reloading the original actionPattern in-place
-      return ActionPattern.scope('defaultScope').create({ ...actionPattern.dataValues })
-        .then(async (newActionPattern) => {
-          await actionPattern.reload();
-          return newActionPattern.reload();
-        });
-    }
-
-    /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.

--- a/app/models/armor.js
+++ b/app/models/armor.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
      * @returns {Promise<Armor>} a copy of the given armor, with
      * `name` set to be the max + 1 over sibling instances.
      */
-    static clone = async (armor) => {
+    static async cloneInstance(armor) {
       delete armor.id;
 
       armor.name = incrementNumSuffix(armor.name);
@@ -19,7 +19,7 @@ module.exports = (sequelize, DataTypes) => {
           await armor.reload();
           return newArmor.reload();
         });
-    };
+    }
 
     /**
      * Helper method for defining associations.

--- a/app/models/armor.js
+++ b/app/models/armor.js
@@ -1,7 +1,26 @@
 const { Model } = require('sequelize');
+const { incrementNumSuffix } = require('../services/validationHelpers');
 
 module.exports = (sequelize, DataTypes) => {
   class Armor extends Model {
+    /**
+     * @param {Armor} armor
+     * @returns {Promise<Armor>} a copy of the given armor, with
+     * `name` set to be the max + 1 over sibling instances.
+     */
+    static clone = async (armor) => {
+      delete armor.id;
+
+      armor.name = incrementNumSuffix(armor.name);
+
+      // Return a copy of the armor after reloading the original armor in-place
+      return Armor.scope('defaultScope').create({ ...armor.dataValues })
+        .then(async (newArmor) => {
+          await armor.reload();
+          return newArmor.reload();
+        });
+    };
+
     /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.

--- a/app/models/armor.js
+++ b/app/models/armor.js
@@ -1,18 +1,14 @@
 const { Model } = require('sequelize');
-const { incrementNumSuffix } = require('../services/validationHelpers');
 
 module.exports = (sequelize, DataTypes) => {
   class Armor extends Model {
     /**
      * @param {Armor} armor
-     * @returns {Promise<Armor>} a copy of the given armor, with
-     * `name` set to be the max + 1 over sibling instances.
+     * @returns {Promise<Armor>} a copy of the given armor with `${name} (copy)`.
      */
     static async cloneInstance(armor) {
       delete armor.id;
-
-      armor.name = incrementNumSuffix(armor.name);
-
+      armor.name = `${armor.name} (copy)`;
       // Return a copy of the armor after reloading the original armor in-place
       return Armor.scope('defaultScope').create({ ...armor.dataValues })
         .then(async (newArmor) => {

--- a/app/models/armor.js
+++ b/app/models/armor.js
@@ -3,21 +3,6 @@ const { Model } = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
   class Armor extends Model {
     /**
-     * @param {Armor} armor
-     * @returns {Promise<Armor>} a copy of the given armor with `${name} (copy)`.
-     */
-    static async cloneInstance(armor) {
-      delete armor.id;
-      armor.name = `${armor.name} (copy)`;
-      // Return a copy of the armor after reloading the original armor in-place
-      return Armor.scope('defaultScope').create({ ...armor.dataValues })
-        .then(async (newArmor) => {
-          await armor.reload();
-          return newArmor.reload();
-        });
-    }
-
-    /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.

--- a/app/models/creature.js
+++ b/app/models/creature.js
@@ -33,7 +33,7 @@ module.exports = (sequelize, DataTypes) => {
 
       Creature.addScope('defaultScope', {
         include: [{
-          model: CreatureType.scope('defaultScope'),
+          model: CreatureType,
           as: 'creatureType',
         }],
       });

--- a/app/models/creature.js
+++ b/app/models/creature.js
@@ -1,27 +1,8 @@
 const { Model } = require('sequelize');
-const { incrementNumSuffix } = require('../services/validationHelpers');
 const { MAX_LEGENDARY_RESISTANCES, MAX_SPELL_SLOTS } = require('../variables');
 
 module.exports = (sequelize, DataTypes) => {
   class Creature extends Model {
-    /**
-     * @param {Creature} creature
-     * @returns {Promise<Creature>} a copy of the given creature, with
-     * `name` set to be the max + 1 over sibling instances.
-     */
-    static async cloneInstance(creature) {
-      delete creature.id;
-
-      creature.name = incrementNumSuffix(creature.name);
-
-      // Return a copy of the creature after reloading the original creature in-place
-      return Creature.scope('defaultScope').create({ ...creature.dataValues })
-        .then(async (newCreature) => {
-          await creature.reload();
-          return newCreature.reload();
-        });
-    }
-
     /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.

--- a/app/models/creature.js
+++ b/app/models/creature.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
      * @returns {Promise<Creature>} a copy of the given creature, with
      * `name` set to be the max + 1 over sibling instances.
      */
-    static clone = async (creature) => {
+    static async cloneInstance(creature) {
       delete creature.id;
 
       creature.name = incrementNumSuffix(creature.name);
@@ -20,7 +20,7 @@ module.exports = (sequelize, DataTypes) => {
           await creature.reload();
           return newCreature.reload();
         });
-    };
+    }
 
     /**
      * Helper method for defining associations.

--- a/app/models/creature.js
+++ b/app/models/creature.js
@@ -1,9 +1,27 @@
 const { Model } = require('sequelize');
-
+const { incrementNumSuffix } = require('../services/validationHelpers');
 const { MAX_LEGENDARY_RESISTANCES, MAX_SPELL_SLOTS } = require('../variables');
 
 module.exports = (sequelize, DataTypes) => {
   class Creature extends Model {
+    /**
+     * @param {Creature} creature
+     * @returns {Promise<Creature>} a copy of the given creature, with
+     * `name` set to be the max + 1 over sibling instances.
+     */
+    static clone = async (creature) => {
+      delete creature.id;
+
+      creature.name = incrementNumSuffix(creature.name);
+
+      // Return a copy of the creature after reloading the original creature in-place
+      return Creature.scope('defaultScope').create({ ...creature.dataValues })
+        .then(async (newCreature) => {
+          await creature.reload();
+          return newCreature.reload();
+        });
+    };
+
     /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
@@ -15,7 +33,7 @@ module.exports = (sequelize, DataTypes) => {
 
       Creature.addScope('defaultScope', {
         include: [{
-          model: CreatureType,
+          model: CreatureType.scope('defaultScope'),
           as: 'creatureType',
         }],
       });

--- a/app/models/creaturetype.js
+++ b/app/models/creaturetype.js
@@ -1,6 +1,5 @@
 const { Model } = require('sequelize');
 const {
-  incrementNumSuffix,
   isArrayOfStrings,
   isArrayOfLabeledDescriptions,
   isValidStat,
@@ -17,14 +16,11 @@ module.exports = (sequelize, DataTypes) => {
   class CreatureType extends Model {
     /**
      * @param {CreatureType} creatureType
-     * @returns {Promise<CreatureType>} a copy of the given creatureType, with
-     * `name` set to be the max + 1 over sibling instances.
+     * @returns {Promise<CreatureType>} a copy of creatureType with `${name} (copy)`.
      */
     static async cloneInstance(creatureType) {
       delete creatureType.id;
-
-      creatureType.name = incrementNumSuffix(creatureType.name);
-
+      creatureType.name = `${creatureType.name} (copy)`;
       // Return a copy of the creatureType after reloading the original creatureType in-place
       return CreatureType.scope('defaultScope').create({ ...creatureType.dataValues })
         .then(async (newCreatureType) => {

--- a/app/models/creaturetype.js
+++ b/app/models/creaturetype.js
@@ -20,7 +20,7 @@ module.exports = (sequelize, DataTypes) => {
      * @returns {Promise<CreatureType>} a copy of the given creatureType, with
      * `name` set to be the max + 1 over sibling instances.
      */
-    static clone = async (creatureType) => {
+    static async cloneInstance(creatureType) {
       delete creatureType.id;
 
       creatureType.name = incrementNumSuffix(creatureType.name);
@@ -31,7 +31,7 @@ module.exports = (sequelize, DataTypes) => {
           await creatureType.reload();
           return newCreatureType.reload();
         });
-    };
+    }
 
     /**
      * Helper method for defining associations.

--- a/app/models/creaturetype.js
+++ b/app/models/creaturetype.js
@@ -15,21 +15,6 @@ const {
 module.exports = (sequelize, DataTypes) => {
   class CreatureType extends Model {
     /**
-     * @param {CreatureType} creatureType
-     * @returns {Promise<CreatureType>} a copy of creatureType with `${name} (copy)`.
-     */
-    static async cloneInstance(creatureType) {
-      delete creatureType.id;
-      creatureType.name = `${creatureType.name} (copy)`;
-      // Return a copy of the creatureType after reloading the original creatureType in-place
-      return CreatureType.scope('defaultScope').create({ ...creatureType.dataValues })
-        .then(async (newCreatureType) => {
-          await creatureType.reload();
-          return newCreatureType.reload();
-        });
-    }
-
-    /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.

--- a/app/models/creaturetype.js
+++ b/app/models/creaturetype.js
@@ -46,7 +46,7 @@ module.exports = (sequelize, DataTypes) => {
 
       CreatureType.addScope('defaultScope', {
         include: [{
-          model: ActionPattern.scope('defaultScope'),
+          model: ActionPattern,
           as: 'actionPatterns',
           order: [['priority', 'ASC']],
         }, {

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -34,9 +34,8 @@ fs
   });
 
 Object.keys(db).forEach((modelName) => {
-  const Model = db[modelName];
-  if (Model.associate) Model.associate(db);
-  Model.addScope('id', (id) => {
+  if (db[modelName].associate) db[modelName].associate(db);
+  db[modelName].addScope('id', (id) => {
     return {
       attributes: { include: ['id'] },
       where: { id },

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -46,15 +46,14 @@ Object.keys(db).forEach((modelName) => {
     /**
      * @param {Model} instance
      * @returns {Promise<Model>} a copy of the given instance. If the model has a 'name' field,
-     * increments its trailing number by one, or adds a trailing ' 1'
+     * increments its trailing number by one, or adds a trailing ' 1'. If the model has an 'index'
+     * or 'priority' field, sets the value to be the max + 1 over sibling instances.
      */
     Model.clone = async (instance) => {
       delete instance.id;
-
-      // Increment name by 1 (e.g. 'goblin' => 'goblin 1' => 'goblin 2')
+      // Increment name (e.g. 'goblin' => 'goblin 1' => 'goblin 2')
       if ({}.hasOwnProperty.call(instance.dataValues, 'name')) {
         const { name } = instance.dataValues;
-
         // If string ends in a number, returns that string and number separated
         // into non-numeric and numeric parts, with the numeric part incremented by one.
         const numSuffix = (string, suffix = '') => {
@@ -69,7 +68,23 @@ Object.keys(db).forEach((modelName) => {
         const { string, suffix } = numSuffix(name);
         instance.name = `${string} ${suffix}`;
       }
-
+      // Increment priority for actionPatterns
+      if ({}.hasOwnProperty.call(instance.dataValues, 'priority')) {
+        instance.priority = Math.max(...(await Model.findAll({
+          where: { creatureTypeId: instance.creatureTypeId },
+          attributes: { include: ['priority'] },
+        }))
+          .map((ap) => ap.priority))
+          + 1;
+      // Increment index for actions
+      } else if ({}.hasOwnProperty.call(instance.dataValues, 'index')) {
+        instance.index = Math.max(...(await Model.findAll({
+          where: { actionPatternId: instance.actionPatternId },
+          attributes: { include: ['index'] },
+        }))
+          .map((ap) => ap.index))
+          + 1;
+      }
       // Return a copy of the instance after reloading the original instance in-place
       return Model.scope('defaultScope').create({ ...instance.dataValues })
         .then(async (newInstance) => {

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -42,57 +42,6 @@ Object.keys(db).forEach((modelName) => {
       where: { id },
     };
   });
-  if (modelName !== 'User') {
-    /**
-     * @param {Model} instance
-     * @returns {Promise<Model>} a copy of the given instance. If the model has a 'name' field,
-     * increments its trailing number by one, or adds a trailing ' 1'. If the model has an 'index'
-     * or 'priority' field, sets the value to be the max + 1 over sibling instances.
-     */
-    Model.clone = async (instance) => {
-      delete instance.id;
-      // Increment name (e.g. 'goblin' => 'goblin 1' => 'goblin 2')
-      if ({}.hasOwnProperty.call(instance.dataValues, 'name')) {
-        const { name } = instance.dataValues;
-        // If string ends in a number, returns that string and number separated
-        // into non-numeric and numeric parts, with the numeric part incremented by one.
-        const numSuffix = (string, suffix = '') => {
-          const nextToLast = string.length - 1;
-          const lastChar = string.charAt(nextToLast);
-          if (Number.isNaN(parseInt(lastChar, 10))) {
-            return { string, suffix: (parseInt(suffix, 10) || 0) + 1 };
-          }
-          return numSuffix(string.slice(0, nextToLast), `${lastChar}${suffix}`);
-        };
-
-        const { string, suffix } = numSuffix(name);
-        instance.name = `${string} ${suffix}`;
-      }
-      // Increment priority for actionPatterns
-      if ({}.hasOwnProperty.call(instance.dataValues, 'priority')) {
-        instance.priority = Math.max(...(await Model.findAll({
-          where: { creatureTypeId: instance.creatureTypeId },
-          attributes: { include: ['priority'] },
-        }))
-          .map((ap) => ap.priority))
-          + 1;
-      // Increment index for actions
-      } else if ({}.hasOwnProperty.call(instance.dataValues, 'index')) {
-        instance.index = Math.max(...(await Model.findAll({
-          where: { actionPatternId: instance.actionPatternId },
-          attributes: { include: ['index'] },
-        }))
-          .map((ap) => ap.index))
-          + 1;
-      }
-      // Return a copy of the instance after reloading the original instance in-place
-      return Model.scope('defaultScope').create({ ...instance.dataValues })
-        .then(async (newInstance) => {
-          await instance.reload();
-          return newInstance.reload();
-        });
-    };
-  }
 });
 
 db.sequelize = sequelize;

--- a/app/models/spell.js
+++ b/app/models/spell.js
@@ -1,6 +1,9 @@
 const { Model } = require('sequelize');
 
-const { isDamageObject } = require('../services/validationHelpers');
+const {
+  incrementNumSuffix,
+  isDamageObject,
+} = require('../services/validationHelpers');
 const {
   MIN_INFORMATION,
   MAX_INFORMATION,
@@ -10,6 +13,24 @@ const {
 
 module.exports = (sequelize, DataTypes) => {
   class Spell extends Model {
+    /**
+     * @param {Spell} spell
+     * @returns {Promise<Spell>} a copy of the given spell, with
+     * `name` set to be the max + 1 over sibling instances.
+     */
+    static clone = async (spell) => {
+      delete spell.id;
+
+      spell.name = incrementNumSuffix(spell.name);
+
+      // Return a copy of the spell after reloading the original spell in-place
+      return Spell.scope('defaultScope').create({ ...spell.dataValues })
+        .then(async (newSpell) => {
+          await spell.reload();
+          return newSpell.reload();
+        });
+    };
+
     /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.

--- a/app/models/spell.js
+++ b/app/models/spell.js
@@ -13,21 +13,6 @@ const {
 module.exports = (sequelize, DataTypes) => {
   class Spell extends Model {
     /**
-     * @param {Spell} spell
-     * @returns {Promise<Spell>} a copy of the given spell, with `${name} (copy)`
-     */
-    static async cloneInstance(spell) {
-      delete spell.id;
-      spell.name = `${spell.name} (copy)`;
-      // Return a copy of the spell after reloading the original spell in-place
-      return Spell.scope('defaultScope').create({ ...spell.dataValues })
-        .then(async (newSpell) => {
-          await spell.reload();
-          return newSpell.reload();
-        });
-    }
-
-    /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.

--- a/app/models/spell.js
+++ b/app/models/spell.js
@@ -18,7 +18,7 @@ module.exports = (sequelize, DataTypes) => {
      * @returns {Promise<Spell>} a copy of the given spell, with
      * `name` set to be the max + 1 over sibling instances.
      */
-    static clone = async (spell) => {
+    static async cloneInstance(spell) {
       delete spell.id;
 
       spell.name = incrementNumSuffix(spell.name);
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
           await spell.reload();
           return newSpell.reload();
         });
-    };
+    }
 
     /**
      * Helper method for defining associations.

--- a/app/models/spell.js
+++ b/app/models/spell.js
@@ -1,7 +1,6 @@
 const { Model } = require('sequelize');
 
 const {
-  incrementNumSuffix,
   isDamageObject,
 } = require('../services/validationHelpers');
 const {
@@ -15,14 +14,11 @@ module.exports = (sequelize, DataTypes) => {
   class Spell extends Model {
     /**
      * @param {Spell} spell
-     * @returns {Promise<Spell>} a copy of the given spell, with
-     * `name` set to be the max + 1 over sibling instances.
+     * @returns {Promise<Spell>} a copy of the given spell, with `${name} (copy)`
      */
     static async cloneInstance(spell) {
       delete spell.id;
-
-      spell.name = incrementNumSuffix(spell.name);
-
+      spell.name = `${spell.name} (copy)`;
       // Return a copy of the spell after reloading the original spell in-place
       return Spell.scope('defaultScope').create({ ...spell.dataValues })
         .then(async (newSpell) => {

--- a/app/models/weapon.js
+++ b/app/models/weapon.js
@@ -13,7 +13,7 @@ module.exports = (sequelize, DataTypes) => {
      * @returns {Promise<Weapon>} a copy of the given weapon, with
      * `name` set to be the max + 1 over sibling instances.
      */
-    static clone = async (weapon) => {
+    static async cloneInstance(weapon) {
       delete weapon.id;
 
       weapon.name = incrementNumSuffix(weapon.name);
@@ -24,7 +24,7 @@ module.exports = (sequelize, DataTypes) => {
           await weapon.reload();
           return newWeapon.reload();
         });
-    };
+    }
 
     /**
      * Helper method for defining associations.

--- a/app/models/weapon.js
+++ b/app/models/weapon.js
@@ -1,7 +1,6 @@
 const { Model } = require('sequelize');
 
 const {
-  incrementNumSuffix,
   isArrayOfStringsAlphabetical,
   isDamageObject,
 } = require('../services/validationHelpers');
@@ -10,14 +9,11 @@ module.exports = (sequelize, DataTypes) => {
   class Weapon extends Model {
     /**
      * @param {Weapon} weapon
-     * @returns {Promise<Weapon>} a copy of the given weapon, with
-     * `name` set to be the max + 1 over sibling instances.
+     * @returns {Promise<Weapon>} a copy of the given weapon with `${name} (copy)`
      */
     static async cloneInstance(weapon) {
       delete weapon.id;
-
-      weapon.name = incrementNumSuffix(weapon.name);
-
+      weapon.name = `${weapon.name} (copy)`;
       // Return a copy of the weapon after reloading the original weapon in-place
       return Weapon.scope('defaultScope').create({ ...weapon.dataValues })
         .then(async (newWeapon) => {

--- a/app/models/weapon.js
+++ b/app/models/weapon.js
@@ -1,9 +1,31 @@
 const { Model } = require('sequelize');
 
-const { isArrayOfStringsAlphabetical, isDamageObject } = require('../services/validationHelpers');
+const {
+  incrementNumSuffix,
+  isArrayOfStringsAlphabetical,
+  isDamageObject,
+} = require('../services/validationHelpers');
 
 module.exports = (sequelize, DataTypes) => {
   class Weapon extends Model {
+    /**
+     * @param {Weapon} weapon
+     * @returns {Promise<Weapon>} a copy of the given weapon, with
+     * `name` set to be the max + 1 over sibling instances.
+     */
+    static clone = async (weapon) => {
+      delete weapon.id;
+
+      weapon.name = incrementNumSuffix(weapon.name);
+
+      // Return a copy of the weapon after reloading the original weapon in-place
+      return Weapon.scope('defaultScope').create({ ...weapon.dataValues })
+        .then(async (newWeapon) => {
+          await weapon.reload();
+          return newWeapon.reload();
+        });
+    };
+
     /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.

--- a/app/models/weapon.js
+++ b/app/models/weapon.js
@@ -8,21 +8,6 @@ const {
 module.exports = (sequelize, DataTypes) => {
   class Weapon extends Model {
     /**
-     * @param {Weapon} weapon
-     * @returns {Promise<Weapon>} a copy of the given weapon with `${name} (copy)`
-     */
-    static async cloneInstance(weapon) {
-      delete weapon.id;
-      weapon.name = `${weapon.name} (copy)`;
-      // Return a copy of the weapon after reloading the original weapon in-place
-      return Weapon.scope('defaultScope').create({ ...weapon.dataValues })
-        .then(async (newWeapon) => {
-          await weapon.reload();
-          return newWeapon.reload();
-        });
-    }
-
-    /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.

--- a/app/seeders/20220605182011-default-action-patterns.js
+++ b/app/seeders/20220605182011-default-action-patterns.js
@@ -3,37 +3,28 @@ const { withTs } = require('./helpers/seederHelpers');
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     const [weapons] = (await queryInterface.sequelize.query('SELECT * FROM "Weapons";'));
-    // Create an action for each weapon, which is just attacking with that weapon once
-    await queryInterface.bulkInsert('Actions', withTs(weapons.map((weapon) => {
-      return {
-        index: 0,
-        weaponId: weapon.id,
-        times: 1,
-      };
-    })));
-    let [actions] = (await queryInterface.sequelize.query('SELECT * FROM "Actions";'));
-
-    // Create an actionPattern for each action
-    await queryInterface.bulkInsert('ActionPatterns', withTs(actions.map(() => {
-      return { priority: 0 };
-    })));
-
-    // Update each existing action to point to a different actionPattern
-    await Promise.allSettled(actions.map(async (action) => {
-      // Setting the actionPatternId to the action's own id should accomplish this
-      await queryInterface.sequelize.query(`UPDATE "Actions" SET "actionPatternId"=${action.id} WHERE id=${action.id};`);
-    }));
-    // Re-fetch the actions
-    [actions] = (await queryInterface.sequelize.query('SELECT * FROM "Actions";'));
-
-    // Update the existing creatureType to have the scimitar actionPattern
     const goblinId = (await queryInterface.sequelize.query('SELECT * FROM "CreatureTypes";'))[0][0].id;
+
+    // Find the ID of the 'scimitar' weapon
     const [scimitarId] = weapons
       .filter((weapon) => weapon.name === 'scimitar')
       .map((weapon) => weapon.id);
-    const [scimitarAction] = actions
-      .filter((action) => action.weaponId === scimitarId);
-    await queryInterface.sequelize.query(`UPDATE "ActionPatterns" SET "creatureTypeId"=${goblinId} WHERE "id"=${scimitarAction.actionPatternId};`);
+
+    // Give the goblin one actionPattern, and find its ID
+    await queryInterface.bulkInsert('ActionPatterns', withTs(
+      [{ creatureTypeId: goblinId, priority: 0 }],
+    ));
+    const actionPatternId = (await queryInterface.sequelize.query('SELECT * FROM "ActionPatterns";'))[0][0].id;
+
+    // Create one action for this actionPattern
+    await queryInterface.bulkInsert('Actions', withTs([
+      {
+        actionPatternId,
+        index: 0,
+        weaponId: scimitarId,
+        times: 1,
+      },
+    ]));
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/app/services/actionPatternService.js
+++ b/app/services/actionPatternService.js
@@ -50,7 +50,7 @@ module.exports = {
     if (!actionPattern) throw new Error(`${CLONE_FAIL} ${NO_ACTION_PATTERN}`);
     // Clear the actionPattern instance ID, and set the priority
     // to be 1 + the max of priorities over sibling instances
-    delete actionPattern.id;
+    delete actionPattern.dataValues.id;
     actionPattern.priority = Math.max(...(
       await ActionPatternCreatureTypeId(actionPattern.creatureTypeId).findAll({
         attributes: { include: ['priority'] },

--- a/app/services/actionPatternService.js
+++ b/app/services/actionPatternService.js
@@ -42,6 +42,11 @@ module.exports = {
       .then((actionPattern) => actionPattern.reload());
   },
 
+  /**
+   * @param {Integer} id of the actionPattern to clone
+   * @returns {Promise<ActionPattern>} a copy of the actionPattern,
+   * with priority 1 + the max over sibling instances.
+   */
   cloneActionPattern: async (id) => {
     // Check that the indicated actionPattern exists
     id = parseInt(id, 10);
@@ -51,13 +56,13 @@ module.exports = {
     // Clear the actionPattern instance ID, and set the priority
     // to be 1 + the max of priorities over sibling instances
     delete actionPattern.dataValues.id;
-    actionPattern.priority = Math.max(...(
+    actionPattern.priority = 1 + Math.max(...(
       await ActionPatternCreatureTypeId(actionPattern.creatureTypeId).findAll({
         attributes: { include: ['priority'] },
-      })).map((ap) => ap.priority)) + 1;
+      })).map((ap) => ap.priority));
     // Return a copy of the actionPattern with its actions, weapons, and spells
-    return ActionPattern.scope('defaultScope').create({ ...actionPattern.dataValues })
-      .then(async (actionPatternClone) => actionPatternClone.reload());
+    return ActionPattern.create({ ...actionPattern.dataValues })
+      .then((actionPatternClone) => actionPatternClone.reload());
   },
 
   /**

--- a/app/services/actionService.js
+++ b/app/services/actionService.js
@@ -79,9 +79,9 @@ module.exports = {
   },
 
   /**
-   * @param {Action} action
-   * @returns {Promise<Action>} a copy of the given action, with
-   * `index` set to be the max + 1 over sibling instances.
+   * @param {Integer} id of the action to clone
+   * @returns {Promise<Action>} a copy of the action,
+   * with index 1 + the max over sibling instances.
    */
   cloneAction: async (id) => {
     // Check that the indicated action exists
@@ -92,13 +92,13 @@ module.exports = {
     // Clear the action instance ID, and set the index to be
     // 1 + the max of index values over sibling instances
     delete action.dataValues.id;
-    action.index = Math.max(...(
+    action.index = 1 + Math.max(...(
       await ActionWithActionPatternId(action.actionPatternId).findAll({
         attributes: { include: ['index'] },
-      })).map((a) => a.index)) + 1;
+      })).map((a) => a.index));
     // Return a copy of the action with its weapons, and spells
-    return Action.scope('defaultScope').create({ ...action.dataValues })
-      .then(async (actionClone) => actionClone.reload());
+    return Action.create({ ...action.dataValues })
+      .then((actionClone) => actionClone.reload());
   },
 
   /**

--- a/app/services/actionService.js
+++ b/app/services/actionService.js
@@ -91,7 +91,7 @@ module.exports = {
     if (!action) throw new Error(`${CLONE_FAIL} ${NO_ACTION}`);
     // Clear the action instance ID, and set the index to be
     // 1 + the max of index values over sibling instances
-    delete action.id;
+    delete action.dataValues.id;
     action.index = Math.max(...(
       await ActionWithActionPatternId(action.actionPatternId).findAll({
         attributes: { include: ['index'] },

--- a/app/services/armorService.js
+++ b/app/services/armorService.js
@@ -45,7 +45,7 @@ module.exports = {
     const armor = await Armor.findByPk(id);
     if (!armor) throw new Error(`${CLONE_FAIL} ${NO_ARMOR}`);
     // Clear the armor instance ID, and set name to 'name (copy)'
-    delete armor.id;
+    delete armor.dataValues.id;
     armor.name = `${armor.name} (copy)`;
     // Return a copy of the armor
     return Armor.create({ ...armor.dataValues });

--- a/app/services/armorService.js
+++ b/app/services/armorService.js
@@ -11,6 +11,7 @@ const CreatureTypeArmorId = (armorId) => CreatureType.scope({ method: ['armorId'
 
 // Error message building blocks
 const CREATE_FAIL = 'Armor creation failed,';
+const CLONE_FAIL = 'Armor clone failed,';
 const UPDATE_FAIL = 'Armor update failed,';
 const DELETE_FAIL = 'Armor deletion failed,';
 const NAME_EXISTS = 'an armor with the given name already exists';
@@ -31,6 +32,23 @@ module.exports = {
     if (await ArmorName(armorObject.name).count()) throw new Error(`${CREATE_FAIL} ${NAME_EXISTS}`);
     // Create the armor
     return Armor.create(armorObject);
+  },
+
+  /**
+   * @param {Armor} armor
+   * @returns {Promise<Armor>} a copy of the given armor with `${name} (copy)`.
+   */
+  cloneArmor: async (id) => {
+    // Check that the indicated armor exists
+    id = parseInt(id, 10);
+    if (!id) throw new Error(`${CLONE_FAIL} ${NO_ARMOR}`);
+    const armor = await Armor.findByPk(id);
+    if (!armor) throw new Error(`${CLONE_FAIL} ${NO_ARMOR}`);
+    // Clear the armor instance ID, and set name to 'name (copy)'
+    delete armor.id;
+    armor.name = `${armor.name} (copy)`;
+    // Return a copy of the armor
+    return Armor.create({ ...armor.dataValues });
   },
 
   /**

--- a/app/services/creatureTypeService.js
+++ b/app/services/creatureTypeService.js
@@ -53,11 +53,11 @@ module.exports = {
   },
 
   /**
-   * @param {CreatureType} creatureType
-   * @returns {Promise<CreatureType>} a copy of creatureType with `${name} (copy)`.
+   * @param {Integer} id of the creatureType to clone
+   * @returns {Promise<CreatureType>} a copy of the creatureType with `${name} (copy)`.
    */
   cloneCreatureType: async (id) => {
-    // Check that the indicated armor exists
+    // Check that the indicated creatureType exists
     id = parseInt(id, 10);
     if (!id) throw new Error(`${CLONE_FAIL} ${NO_CREATURE_TYPE}`);
     const creatureType = await CreatureType.findByPk(id);
@@ -67,8 +67,8 @@ module.exports = {
     creatureType.name = `${creatureType.name} (copy)`;
     // Return a copy of the creatureType with its armor,
     // actionPatterns, actions, weapons, and spells
-    return CreatureType.scope('defaultScope').create({ ...creatureType.dataValues })
-      .then(async (newCreatureType) => newCreatureType.reload());
+    return CreatureType.create({ ...creatureType.dataValues })
+      .then((newCreatureType) => newCreatureType.reload());
   },
 
   /**

--- a/app/services/creatureTypeService.js
+++ b/app/services/creatureTypeService.js
@@ -61,9 +61,9 @@ module.exports = {
     id = parseInt(id, 10);
     if (!id) throw new Error(`${CLONE_FAIL} ${NO_CREATURE_TYPE}`);
     const creatureType = await CreatureType.findByPk(id);
-    if (!creatureType) throw new Error(`${CLONE_FAIL} ${NO_ARMOR}`);
+    if (!creatureType) throw new Error(`${CLONE_FAIL} ${NO_CREATURE_TYPE}`);
     // Clear the creatureType instance ID, and set name to 'name (copy)'
-    delete creatureType.id;
+    delete creatureType.dataValues.id;
     creatureType.name = `${creatureType.name} (copy)`;
     // Return a copy of the creatureType with its armor,
     // actionPatterns, actions, weapons, and spells

--- a/app/services/creatureTypeService.js
+++ b/app/services/creatureTypeService.js
@@ -20,6 +20,7 @@ const CreatureTypeActionPatternIds = (creatureTypeId) => CreatureType.scope({ me
 
 // Error message building blocks
 const CREATE_FAIL = 'CreatureType creation failed,';
+const CLONE_FAIL = 'CreatureType clone failed,';
 const UPDATE_FAIL = 'CreatureType update failed,';
 const DELETE_FAIL = 'CreatureType deletion failed,';
 const NAME_EXISTS = 'a creatureType with the given name already exists';
@@ -49,6 +50,25 @@ module.exports = {
     // Create the creatureType, returning it with its armor
     return CreatureType.create(creatureTypeObject)
       .then((creatureType) => creatureType.reload());
+  },
+
+  /**
+   * @param {CreatureType} creatureType
+   * @returns {Promise<CreatureType>} a copy of creatureType with `${name} (copy)`.
+   */
+  cloneCreatureType: async (id) => {
+    // Check that the indicated armor exists
+    id = parseInt(id, 10);
+    if (!id) throw new Error(`${CLONE_FAIL} ${NO_CREATURE_TYPE}`);
+    const creatureType = await CreatureType.findByPk(id);
+    if (!creatureType) throw new Error(`${CLONE_FAIL} ${NO_ARMOR}`);
+    // Clear the creatureType instance ID, and set name to 'name (copy)'
+    delete creatureType.id;
+    creatureType.name = `${creatureType.name} (copy)`;
+    // Return a copy of the creatureType with its armor,
+    // actionPatterns, actions, weapons, and spells
+    return CreatureType.scope('defaultScope').create({ ...creatureType.dataValues })
+      .then(async (newCreatureType) => newCreatureType.reload());
   },
 
   /**

--- a/app/services/spellService.js
+++ b/app/services/spellService.js
@@ -43,7 +43,7 @@ module.exports = {
     const spell = await Spell.findByPk(id);
     if (!spell) throw new Error(`${CLONE_FAIL} ${NO_SPELL}`);
     // Clear the spell instance ID, and set name to 'name (copy)'
-    delete spell.id;
+    delete spell.dataValues.id;
     spell.name = `${spell.name} (copy)`;
     // Return a copy of the spell
     return Spell.create({ ...spell.dataValues });

--- a/app/services/spellService.js
+++ b/app/services/spellService.js
@@ -33,8 +33,8 @@ module.exports = {
   },
 
   /**
-   * @param {Spell} spell
-   * @returns {Promise<Spell>} a copy of the given spell, with `${name} (copy)`
+   * @param {Integer} id of the spell to copy
+   * @returns {Promise<Spell>} a copy of the spell, with `${name} (copy)`
    */
   cloneSpell: async (id) => {
     // Check that the indicated spell exists

--- a/app/services/spellService.js
+++ b/app/services/spellService.js
@@ -9,6 +9,7 @@ const SpellName = (name) => Spell.scope({ method: ['name', name] });
 
 // Error message building blocks
 const CREATE_FAIL = 'Spell creation failed,';
+const CLONE_FAIL = 'Spell clone failed,';
 const UPDATE_FAIL = 'Spell update failed,';
 const DELETE_FAIL = 'Spell deletion failed,';
 const NAME_EXISTS = 'a spell with the given name already exists';
@@ -29,6 +30,23 @@ module.exports = {
     if (await SpellName(spellObject.name).count()) throw new Error(`${CREATE_FAIL} ${NAME_EXISTS}`);
     // Create the spell
     return Spell.create(spellObject);
+  },
+
+  /**
+   * @param {Spell} spell
+   * @returns {Promise<Spell>} a copy of the given spell, with `${name} (copy)`
+   */
+  cloneSpell: async (id) => {
+    // Check that the indicated spell exists
+    id = parseInt(id, 10);
+    if (!id) throw new Error(`${CLONE_FAIL} ${NO_SPELL}`);
+    const spell = await Spell.findByPk(id);
+    if (!spell) throw new Error(`${CLONE_FAIL} ${NO_SPELL}`);
+    // Clear the spell instance ID, and set name to 'name (copy)'
+    delete spell.id;
+    spell.name = `${spell.name} (copy)`;
+    // Return a copy of the spell
+    return Spell.create({ ...spell.dataValues });
   },
 
   /**

--- a/app/services/validationHelpers.js
+++ b/app/services/validationHelpers.js
@@ -10,6 +10,22 @@ const {
 
 module.exports = {
   /**
+   * Given a string that ends in a number, returns that string and number
+   * with the numeric part incremented by one. Otherwise, return that string
+   * contatenated with ' 1'.
+   * @param {String} string
+   * @param {String} suffix
+   * @returns {String}
+   */
+  incrementNumSuffix: (string, suffix = '') => {
+    const nextToLast = string.length - 1;
+    const lastChar = string.charAt(nextToLast);
+    if (Number.isNaN(parseInt(lastChar, 10))) {
+      return `${string} ${(parseInt(suffix, 10) || 0) + 1}`;
+    }
+    return module.exports.incrementNumSuffix(string.slice(0, nextToLast), `${lastChar}${suffix}`);
+  },
+  /**
    * @param {Object} inputObject
    * @param {Array<String>} allowedParams
    * @returns {Object} strippedInputObject

--- a/app/services/validationHelpers.js
+++ b/app/services/validationHelpers.js
@@ -10,22 +10,6 @@ const {
 
 module.exports = {
   /**
-   * Given a string that ends in a number, returns that string and number
-   * with the numeric part incremented by one. Otherwise, return that string
-   * contatenated with ' 1'.
-   * @param {String} string
-   * @param {String} suffix
-   * @returns {String}
-   */
-  incrementNumSuffix: (string, suffix = '') => {
-    const nextToLast = string.length - 1;
-    const lastChar = string.charAt(nextToLast);
-    if (Number.isNaN(parseInt(lastChar, 10))) {
-      return `${string} ${(parseInt(suffix, 10) || 0) + 1}`;
-    }
-    return module.exports.incrementNumSuffix(string.slice(0, nextToLast), `${lastChar}${suffix}`);
-  },
-  /**
    * @param {Object} inputObject
    * @param {Array<String>} allowedParams
    * @returns {Object} strippedInputObject

--- a/app/services/weaponService.js
+++ b/app/services/weaponService.js
@@ -43,7 +43,7 @@ module.exports = {
     const weapon = await Weapon.findByPk(id);
     if (!weapon) throw new Error(`${CLONE_FAIL} ${NO_WEAPON}`);
     // Clear the weapon instance ID, and set name to 'name (copy)'
-    delete weapon.id;
+    delete weapon.dataValues.id;
     weapon.name = `${weapon.name} (copy)`;
     // Return a copy of the weapon
     return Weapon.create({ ...weapon.dataValues });

--- a/app/services/weaponService.js
+++ b/app/services/weaponService.js
@@ -33,8 +33,8 @@ module.exports = {
   },
 
   /**
-   * @param {Weapon} weapon
-   * @returns {Promise<Weapon>} a copy of the given weapon with `${name} (copy)`
+   * @param {Integer} id of the weapon to copy
+   * @returns {Promise<Weapon>} a copy of the weapon with `${name} (copy)`
    */
   async cloneWeapon(id) {
     // Check that the indicated weapon exists

--- a/app/services/weaponService.js
+++ b/app/services/weaponService.js
@@ -9,6 +9,7 @@ const WeaponName = (name) => Weapon.scope({ method: ['name', name] });
 
 // Error message building blocks
 const CREATE_FAIL = 'Weapon creation failed,';
+const CLONE_FAIL = 'Weapon clone failed,';
 const UPDATE_FAIL = 'Weapon update failed,';
 const DELETE_FAIL = 'Weapon deletion failed,';
 const NAME_EXISTS = 'a weapon with the given name already exists';
@@ -29,6 +30,23 @@ module.exports = {
     if (await WeaponName(weaponObject.name).count()) throw new Error(`${CREATE_FAIL} ${NAME_EXISTS}`);
     // Create the weapon
     return Weapon.create(weaponObject);
+  },
+
+  /**
+   * @param {Weapon} weapon
+   * @returns {Promise<Weapon>} a copy of the given weapon with `${name} (copy)`
+   */
+  async cloneWeapon(id) {
+    // Check that the indicated weapon exists
+    id = parseInt(id, 10);
+    if (!id) throw new Error(`${CLONE_FAIL} ${NO_WEAPON}`);
+    const weapon = await Weapon.findByPk(id);
+    if (!weapon) throw new Error(`${CLONE_FAIL} ${NO_WEAPON}`);
+    // Clear the weapon instance ID, and set name to 'name (copy)'
+    delete weapon.id;
+    weapon.name = `${weapon.name} (copy)`;
+    // Return a copy of the weapon
+    return Weapon.create({ ...weapon.dataValues });
   },
 
   /**

--- a/app/test/actionPatternService.spec.js
+++ b/app/test/actionPatternService.spec.js
@@ -49,7 +49,7 @@ describe('ActionPattern Service', () => {
           throw new Error('createActionPattern should have thrown an error');
         }
       } catch (error) {
-        assert.equal(error.message, 'ActionPattern creation failed, fields missing: creatureTypeId,priority');
+        assert.equal(error.message, 'ActionPattern creation failed, fields missing: creatureTypeId');
       }
     });
 

--- a/app/test/actionPatternService.spec.js
+++ b/app/test/actionPatternService.spec.js
@@ -113,6 +113,37 @@ describe('ActionPattern Service', () => {
     });
   });
 
+  describe('cloneActionPattern', () => {
+    it('Should throw an error if an invalid ID is passed', async () => {
+      try {
+        await actionPatternService.cloneActionPattern('invalid');
+        throw new Error('cloneActionPattern should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'ActionPattern clone failed, no actionPattern found for the given ID');
+      }
+      try {
+        await actionPatternService.cloneActionPattern(9999);
+        throw new Error('cloneActionPattern should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'ActionPattern clone failed, no actionPattern found for the given ID');
+      }
+    });
+
+    it('Should return a copy of the actionPattern with priority 1 + the max of priorities over sibling instances', async () => {
+      const result = await actionPatternService.cloneActionPattern(actionPattern.id);
+      expectedActionPatterns += 1;
+      assert.hasAnyKeys(result, 'dataValues');
+      const values = result.dataValues;
+      assert.hasAllKeys(values, ['id', 'creatureTypeId', 'priority', 'createdAt', 'updatedAt', 'actions']);
+      assert.notEqual(values.id, actionPattern.id);
+      assert.equal(values.creatureTypeId, actionPattern.creatureTypeId);
+      assert.equal(values.priority, actionPattern.priority + 1);
+
+      // Check that one actionPattern was created
+      assert.lengthOf(await ActionPattern.findAll(), expectedActionPatterns);
+    });
+  });
+
   describe('getActionPattern', () => {
     it('Should return null if an invalid id is passed', async () => {
       assert.isNull(await actionPatternService.getActionPattern('invalid'));

--- a/app/test/actionService.spec.js
+++ b/app/test/actionService.spec.js
@@ -170,6 +170,37 @@ describe('Action Service', () => {
     });
   });
 
+  describe('cloneAction', () => {
+    it('Should throw an error if an invalid ID is passed', async () => {
+      try {
+        await actionService.cloneAction('invalid');
+        throw new Error('cloneAction should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'Action clone failed, no action found for the given ID');
+      }
+      try {
+        await actionService.cloneAction(9999);
+        throw new Error('cloneAction should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'Action clone failed, no action found for the given ID');
+      }
+    });
+
+    it('Should return a copy of the action with index 1 + the max of index values over sibling instances', async () => {
+      const result = await actionService.cloneAction(action.id);
+      expectedActions += 1;
+      assert.hasAnyKeys(result, 'dataValues');
+      const values = result.dataValues;
+      assert.hasAllKeys(values, ['id', 'actionPatternId', 'index', 'weaponId', 'times', 'spellId', 'restrictions', 'other', 'createdAt', 'updatedAt', 'weapon', 'spell']);
+      assert.notEqual(values.id, action.id);
+      assert.equal(values.actionPatternId, action.actionPatternId);
+      assert.equal(values.index, action.index + 1);
+
+      // Check that one action was created
+      assert.lengthOf(await Action.findAll(), expectedActions);
+    });
+  });
+
   describe('getAction', () => {
     it('Should return null if an invalid id is passed', async () => {
       assert.isNull(await actionService.getAction('invalid'));

--- a/app/test/actionService.spec.js
+++ b/app/test/actionService.spec.js
@@ -57,7 +57,7 @@ describe('Action Service', () => {
       try {
         if (await actionService.createAction({})) throw new Error('createAction should have thrown an error');
       } catch (error) {
-        assert.equal(error.message, 'Action creation failed, fields missing: actionPatternId,index');
+        assert.equal(error.message, 'Action creation failed, fields missing: actionPatternId');
       }
     });
 

--- a/app/test/armorService.spec.js
+++ b/app/test/armorService.spec.js
@@ -85,6 +85,36 @@ describe('Armor Service', () => {
     });
   });
 
+  describe('cloneArmor', () => {
+    it('Should throw an error if an invalid ID is passed', async () => {
+      try {
+        await armorService.cloneArmor('invalid');
+        throw new Error('cloneArmor should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'Armor clone failed, no armor found for the given ID');
+      }
+      try {
+        await armorService.cloneArmor(9999);
+        throw new Error('cloneArmor should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'Armor clone failed, no armor found for the given ID');
+      }
+    });
+
+    it('Should return a copy of the armor with "name (copy)"', async () => {
+      const result = await armorService.cloneArmor(armor.id);
+      expectedArmors += 1;
+      assert.hasAnyKeys(result, 'dataValues');
+      const values = result.dataValues;
+      assert.hasAllKeys(values, ['id', 'name', 'type', 'baseAC', 'disadvantage', 'createdAt', 'updatedAt']);
+      assert.notEqual(values.id, armor.id);
+      assert.equal(values.name, `${armor.name} (copy)`);
+
+      // Check that one armor was created
+      assert.lengthOf(await Armor.findAll(), expectedArmors);
+    });
+  });
+
   describe('getArmor', () => {
     it('Should return null if an invalid id is passed', async () => {
       assert.isNull(await armorService.getArmor('invalid'));

--- a/app/test/creatureTypeService.spec.js
+++ b/app/test/creatureTypeService.spec.js
@@ -143,6 +143,36 @@ describe('CreatureType Service', () => {
     });
   });
 
+  describe('cloneCreatureType', () => {
+    it('Should throw an error if an invalid ID is passed', async () => {
+      try {
+        await creatureTypeService.cloneCreatureType('invalid');
+        throw new Error('cloneCreatureType should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'CreatureType clone failed, no creatureType found for the given ID');
+      }
+      try {
+        await creatureTypeService.cloneCreatureType(9999);
+        throw new Error('cloneCreatureType should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'CreatureType clone failed, no creatureType found for the given ID');
+      }
+    });
+
+    it('Should return a copy of the creatureType with "name (copy)"', async () => {
+      const result = await creatureTypeService.cloneCreatureType(creatureType.id);
+      expectedCreatureTypes += 1;
+      assert.hasAnyKeys(result, 'dataValues');
+      const values = result.dataValues;
+      assert.hasAllKeys(values, ['id', 'name', 'size', 'type', 'tags', 'alignment', 'armorId', 'hasShield', 'hitDie', 'numDice', 'maxHP', 'speed', 'flySpeed', 'swimSpeed', 'climbSpeed', 'burrowSpeed', 'hover', 'str', 'dex', 'con', 'int', 'wis', 'cha', 'savingThrows', 'skills', 'resistances', 'senses', 'passivePerception', 'languages', 'challengeRating', 'proficiencyBonus', 'legendaryResistances', 'specialAbilities', 'spellcasting', 'spellSlots', 'innateSpells', 'legendaryActions', 'reactions', 'lairActions', 'regionalEffects', 'createdAt', 'updatedAt', 'actionPatterns', 'armor']);
+      assert.notEqual(values.id, creatureType.id);
+      assert.equal(values.name, `${creatureType.name} (copy)`);
+
+      // Check that one creatureType was created
+      assert.lengthOf(await CreatureType.findAll(), expectedCreatureTypes);
+    });
+  });
+
   describe('getCreatureType', () => {
     it('Should return null if an invalid id is passed', async () => {
       assert.isNull(await creatureTypeService.getCreatureType('invalid'));

--- a/app/test/spellService.spec.js
+++ b/app/test/spellService.spec.js
@@ -106,6 +106,36 @@ describe('Spell Service', () => {
     });
   });
 
+  describe('cloneSpell', () => {
+    it('Should throw an error if an invalid ID is passed', async () => {
+      try {
+        await spellService.cloneSpell('invalid');
+        throw new Error('cloneSpell should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'Spell clone failed, no spell found for the given ID');
+      }
+      try {
+        await spellService.cloneSpell(9999);
+        throw new Error('cloneSpell should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'Spell clone failed, no spell found for the given ID');
+      }
+    });
+
+    it('Should return a copy of the spell with "name (copy)"', async () => {
+      const result = await spellService.cloneSpell(spell.id);
+      expectedSpells += 1;
+      assert.hasAnyKeys(result, 'dataValues');
+      const values = result.dataValues;
+      assert.hasAllKeys(values, ['id', 'name', 'level', 'school', 'castingTime', 'range', 'components', 'duration', 'saveType', 'saveStillHalf', 'description', 'damages', 'createdAt', 'updatedAt']);
+      assert.notEqual(values.id, spell.id);
+      assert.equal(values.name, `${spell.name} (copy)`);
+
+      // Check that one spell was created
+      assert.lengthOf(await Spell.findAll(), expectedSpells);
+    });
+  });
+
   describe('getSpell', () => {
     it('Should return null if an invalid id is passed', async () => {
       assert.isNull(await spellService.getSpell('invalid'));

--- a/app/test/weaponService.spec.js
+++ b/app/test/weaponService.spec.js
@@ -78,6 +78,36 @@ describe('Weapon Service', () => {
     });
   });
 
+  describe('cloneWeapon', () => {
+    it('Should throw an error if an invalid ID is passed', async () => {
+      try {
+        await weaponService.cloneWeapon('invalid');
+        throw new Error('cloneWeapon should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'Weapon clone failed, no weapon found for the given ID');
+      }
+      try {
+        await weaponService.cloneWeapon(9999);
+        throw new Error('cloneWeapon should have thrown an error');
+      } catch (error) {
+        assert.equal(error.message, 'Weapon clone failed, no weapon found for the given ID');
+      }
+    });
+
+    it('Should return a copy of the weapon with "name (copy)"', async () => {
+      const result = await weaponService.cloneWeapon(weapon.id);
+      expectedWeapons += 1;
+      assert.hasAnyKeys(result, 'dataValues');
+      const values = result.dataValues;
+      assert.hasAllKeys(values, ['id', 'name', 'damages', 'properties', 'normalRange', 'longRange', 'attackShape', 'save', 'saveType', 'saveStillHalf', 'createdAt', 'updatedAt']);
+      assert.notEqual(values.id, weapon.id);
+      assert.equal(values.name, `${weapon.name} (copy)`);
+
+      // Check that one weapon was created
+      assert.lengthOf(await Weapon.findAll(), expectedWeapons);
+    });
+  });
+
   describe('getWeapon', () => {
     it('Should return null if an invalid id is passed', async () => {
       assert.isNull(await weaponService.getWeapon('invalid'));


### PR DESCRIPTION
Each service that isn't for `User` or `Creature` should have a `cloneModel` function.
- [x] `cloneArmor`, `cloneCreatureType`, `cloneWeapon`, and `cloneSpell` should have `name = {name} copy`.
- [x] `cloneActionPattern` should have `priority = max + 1` over values for sibling `actionPatterns`.
- [x]  `cloneAction` should have `index = max + 1` over values for sibling `actions` .

Additionally:
- [x] `creatureTypeService` should have `spawnCreature(creatureType)`, which spawns a creature with number suffix equal to 1 + the max of all number suffixes over sibling instance names.

Unit Tests:
- [x] All `cloneModel` functions.
- [x] The `spawnCreature(creatureType)` function.